### PR TITLE
Avoid loading the entire AWS SDK

### DIFF
--- a/resque_to_cloudwatch.gemspec
+++ b/resque_to_cloudwatch.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   
-  spec.add_dependency "aws-sdk"
+  spec.add_dependency "aws-sdk-cloudfront"
   spec.add_dependency "eventmachine"
   spec.add_dependency "redis"
   spec.add_dependency "simple-graphite"


### PR DESCRIPTION
This gem relies only on CloudFront, so that's all we should specify.

The previous version of the AWS SDK came with all the classes but used `autoload` to keep them from being loaded into memory until needed. The gem upgrade caused all AWS gems to be eager-loaded into memory when `Bundler.require` is executed.